### PR TITLE
Fix memory leaks and cleanup training

### DIFF
--- a/Toguzkumalak/game.cpp
+++ b/Toguzkumalak/game.cpp
@@ -3,12 +3,14 @@
 #include "game.h"
 
 Game::Game(int a_size)
+    : boardArray(nullptr)
 {
     setActionSize(a_size);
     reset();
 }
 
 Game::Game(const Game& game)
+    : boardArray(nullptr)
 {
     size_t size = game.action_size * 2;
     setActionSize(game.action_size);
@@ -29,12 +31,12 @@ Game::Game(const Game& game)
 Game::~Game()
 {
     delete[] boardArray;
+    boardArray = nullptr;
 }
 
 void Game::setActionSize(int a_size)
 {
     action_size = std::clamp(a_size, 2, 100);
-    action_size = a_size;
     max_stones = a_size * a_size * 2;
     goal = a_size * a_size + 1;
 }
@@ -43,6 +45,9 @@ void Game::setActionSize(int a_size)
 void Game::reset()
 {
     size_t size = action_size * 2;
+    if (boardArray) {
+        delete[] boardArray;
+    }
     boardArray = new int[size];
     std::fill(boardArray, boardArray + size, action_size);
     player = player1_score = player2_score = 0;
@@ -295,7 +300,7 @@ Game::board Game::copyBoard()
 {
     size_t size = action_size * 2;
     int* copy = new int[size];
-    std::memcpy(copy, boardArray, size * sizeof(board));
+    std::memcpy(copy, boardArray, size * sizeof(int));
     return copy;
 }
 

--- a/Toguzkumalak/game.h
+++ b/Toguzkumalak/game.h
@@ -17,7 +17,7 @@ public:
 	int action_size;
 	int max_stones;
 	int goal;
-	board boardArray;
+        board boardArray = nullptr;
 	int player;
 	int player1_score;
 	int player2_score;

--- a/Toguzkumalak/train.cpp
+++ b/Toguzkumalak/train.cpp
@@ -89,15 +89,12 @@ void start_training(const std::shared_ptr<TNET>& model, const std::string& datas
         printf("Loading dataset from %s\n", dataset_path.c_str());
         dataset.load(dataset_path);
         printf("Dataset loaded: %zu states, %zu policies, %zu values\n", dataset.states.size(), dataset.policies.size(), dataset.values.size());
-        std::vector<std::thread> threads;
         if (num_threads > 1) {
-#pragma omp parallel for
-			for (int i = 0; i < num_threads; ++i) {
+            for (int i = 0; i < num_threads; ++i) {
                 train(model, dataset, i, cfg);
-			}
-        }
-        else {
-			train(model, dataset, 0, cfg);
+            }
+        } else {
+            train(model, dataset, 0, cfg);
         }
     }
     catch (const c10::Error& e) {

--- a/cython/brain.py
+++ b/cython/brain.py
@@ -260,6 +260,7 @@ def simulate_train(model):
     print("Training completed.")
     
 if __name__ == "__main__":
+    pass
     # input_data = torch.tensor([9.000000, 9.000000, 9.000000, 9.000000, 9.000000, 9.000000, 9.000000, 9.000000, 
     #                         9.000000, 9.000000, 9.000000, 9.000000, 9.000000, 9.000000, 9.000000, 9.000000, 
     #                         9.000000, 9.000000, 0.000000, 0.000000, 0.000000], dtype=torch.float32).view(1, -1)
@@ -277,4 +278,3 @@ if __name__ == "__main__":
     # print("After loading weights:")
     # print(output_loaded)
 
-    torch.int16


### PR DESCRIPTION
## Summary
- set `boardArray` to `nullptr` and free it during reset
- clamp action size properly
- correct board copy memory sizing
- train sequentially to avoid concurrency issues
- clean up trailing line in brain.py

## Testing
- `python3 -m py_compile cython/*.py`
- `g++ -std=c++17 -c Toguzkumalak/game.cpp -I./Toguzkumalak -o /tmp/game.o`


------
https://chatgpt.com/codex/tasks/task_e_688b564c50a08320ae23e69a2db4071d